### PR TITLE
Ensure Tailwind scripts run PostCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "npx tailwindcss -i ./src/styles/tailwind.css -o ./style.css --watch",
-    "build": "npx tailwindcss -i ./src/styles/tailwind.css -o ./style.css --minify"
+    "dev": "npx tailwindcss -i ./src/styles/tailwind.css -o ./style.css --watch --postcss",
+    "build": "npx tailwindcss -i ./src/styles/tailwind.css -o ./style.css --minify --postcss"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.16",


### PR DESCRIPTION
## Summary
- ensure the Tailwind dev and build scripts pass the `--postcss` flag so PostCSS plugins execute

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2c1c45cf4832d95c26dbdfda69e75