### PR TITLE
Add ‘Who We Help’ section below services

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,49 @@
       </div>
     </section>
     <!-- What We Do section end -->
+    <!-- Who We Help section start -->
+    <section class="w-full">
+      <div class="max-w-6xl px-6 py-20 mx-auto sm:px-8 lg:px-12">
+        <div class="max-w-3xl mx-auto text-center">
+          <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+            Who We Help
+          </h2>
+          <p class="mt-4 text-base text-gray-200">
+            We work with ambitious organisations that rely on technology to grow and deliver better experiences.
+          </p>
+        </div>
+        <div
+          class="grid grid-cols-1 gap-4 mt-12 sm:grid-cols-2 lg:grid-cols-3 lg:gap-6"
+        >
+          <div
+            class="px-6 py-4 text-sm font-medium text-center text-white transition border rounded-full border-white/10 bg-white/5 backdrop-blur-sm"
+          >
+            Education &amp; Training
+          </div>
+          <div
+            class="px-6 py-4 text-sm font-medium text-center text-white transition border rounded-full border-white/10 bg-white/5 backdrop-blur-sm"
+          >
+            Manufacturing &amp; Engineering
+          </div>
+          <div
+            class="px-6 py-4 text-sm font-medium text-center text-white transition border rounded-full border-white/10 bg-white/5 backdrop-blur-sm"
+          >
+            Design &amp; Creative Studios
+          </div>
+          <div
+            class="px-6 py-4 text-sm font-medium text-center text-white transition border rounded-full border-white/10 bg-white/5 backdrop-blur-sm"
+          >
+            Professional Services
+          </div>
+          <div
+            class="px-6 py-4 text-sm font-medium text-center text-white transition border rounded-full border-white/10 bg-white/5 backdrop-blur-sm"
+          >
+            Tech Startups
+          </div>
+        </div>
+      </div>
+    </section>
+    <!-- Who We Help section end -->
     <!-- Logo header (add later) -->
     <!-- Sections go here -->
   </body>


### PR DESCRIPTION
## Summary
- add a Who We Help section after the services block with introductory copy and client type pills
- implement responsive grid layout for five client segments while keeping the existing styling palette

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68e2cfce88c8832da8220a1f9156b363