### PR TITLE
Add 'About Halesia Group' / Credibility section

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,6 +252,49 @@
       </div>
     </section>
     <!-- How It Works section end -->
+    <!-- About section start -->
+    <section class="w-full border-t border-white/10">
+      <div class="max-w-6xl px-6 py-20 mx-auto sm:px-8 lg:px-12">
+        <div class="max-w-3xl mx-auto text-center">
+          <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+            About Halesia Group
+          </h2>
+          <p class="mt-4 text-base text-gray-100">
+            Halesia Group is a founder-led technical studio that designs, builds, and maintains bespoke software systems. We act as a long-term technical partner—combining engineering expertise with business insight.
+          </p>
+        </div>
+        <div class="grid gap-8 mt-12 md:grid-cols-3">
+          <div class="flex flex-col gap-4 p-8 border rounded-2xl border-white/10 bg-white/5 md:flex-row md:items-start">
+            <div class="hidden w-12 h-12 rounded-full bg-white/10 md:flex" aria-hidden="true"></div>
+            <div class="space-y-2">
+              <h3 class="text-lg font-semibold text-white">Proven experience</h3>
+              <p class="text-sm leading-relaxed text-gray-100">
+                Built and maintained production-grade systems across industries with a focus on reliability.
+              </p>
+            </div>
+          </div>
+          <div class="flex flex-col gap-4 p-8 border rounded-2xl border-white/10 bg-white/5 md:flex-row md:items-start">
+            <div class="hidden w-12 h-12 rounded-full bg-white/10 md:flex" aria-hidden="true"></div>
+            <div class="space-y-2">
+              <h3 class="text-lg font-semibold text-white">Ongoing partnership</h3>
+              <p class="text-sm leading-relaxed text-gray-100">
+                Continuous improvement, monitoring, and support to keep your software evolving with your business.
+              </p>
+            </div>
+          </div>
+          <div class="flex flex-col gap-4 p-8 border rounded-2xl border-white/10 bg-white/5 md:flex-row md:items-start">
+            <div class="hidden w-12 h-12 rounded-full bg-white/10 md:flex" aria-hidden="true"></div>
+            <div class="space-y-2">
+              <h3 class="text-lg font-semibold text-white">Founder-led</h3>
+              <p class="text-sm leading-relaxed text-gray-100">
+                Every engagement is overseen by an experienced engineer who stays close to the details.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    <!-- About section end -->
     <!-- Logo header (add later) -->
     <!-- Sections go here -->
   </body>


### PR DESCRIPTION
## Summary
- add an "About Halesia Group" section beneath the process overview with consistent spacing and divider styling
- describe the studio and highlight three credibility points in a responsive grid with optional avatar placeholders

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e2d2391100832db7552d606c5b97d1