### PR TITLE
Add Call-to-Action band (Book a Call)

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,6 +295,34 @@
       </div>
     </section>
     <!-- About section end -->
+    <!-- CTA section start -->
+    <section class="w-full bg-[#162b3f] border-t border-white/10">
+      <div
+        class="max-w-5xl px-6 py-20 mx-auto sm:px-8 lg:px-12"
+      >
+        <div
+          class="flex flex-col items-center justify-between gap-8 text-center md:flex-row md:text-left"
+        >
+          <div class="space-y-4">
+            <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+              Let’s build something that lasts.
+            </h2>
+            <p class="text-base text-gray-100">
+              Book a short call to explore how we can strengthen your technology stack.
+            </p>
+          </div>
+          <div class="flex justify-center md:justify-end">
+            <a
+              href="#contact"
+              class="inline-flex items-center justify-center px-6 py-3 text-base font-semibold text-white transition-colors border border-white rounded-full hover:bg-white hover:text-[#0b1a27] focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-[#162b3f]"
+            >
+              Book a 20-Minute Call
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+    <!-- CTA section end -->
     <!-- Logo header (add later) -->
     <!-- Sections go here -->
   </body>


### PR DESCRIPTION
## Summary
- add a high-contrast CTA section beneath the About content
- include supporting copy and a prominent call-to-action button linking to the contact section

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68e2d34bc3c8832d96351870f0fc5619