### PR TITLE
Fix logo paths for local viewing

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
         <div class="flex flex-col items-center text-center gap-10 lg:flex-row lg:items-center lg:justify-between lg:text-left lg:gap-16">
           <div class="flex justify-center w-full lg:w-auto lg:justify-start">
             <img
-              src="/img/logo.png"
+              src="./img/logo.png"
               alt="Halesia Group logo"
               class="w-32 h-auto lg:w-36"
             />
@@ -292,7 +292,7 @@
       <div class="max-w-6xl px-6 py-8 mx-auto md:px-8 lg:px-12">
         <div class="flex flex-col items-center justify-between gap-4 text-sm text-gray-100 md:flex-row">
           <div class="flex items-center gap-3">
-            <img src="/img/logo.svg" alt="Halesia Group" class="h-8 w-auto" />
+            <img src="./img/logo.png" alt="Halesia Group" class="h-8 w-auto" />
             <span class="sr-only">Halesia Group</span>
           </div>
           <p class="text-center md:text-right">© 2025 Halesia Group. All rights reserved.</p>


### PR DESCRIPTION
## Summary
- use relative paths for the hero and footer logos so the image loads when the site is opened from the filesystem
- ensure the footer references the existing PNG asset instead of a missing SVG

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2e4782fa4832dac344d5239e53f9e