### PR TITLE
Increase logo size & unify background colour with logo palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,22 +23,25 @@
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="icon" href="/img/favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/img/favicon.png" />
-    <meta name="theme-color" content="#0b1a27" />
+    <meta name="theme-color" content="#0e1d28" />
     <meta name="robots" content="index, follow" />
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body class="font-sans bg-white text-[#0b1a27]">
+  <!-- Brand palette update start -->
+  <body class="font-sans bg-white text-[#0e1d28]">
     <!-- Hero section start -->
-    <section class="w-full text-white bg-[#0b1a27] border-b border-white/10">
+    <section class="w-full text-white bg-[#0e1d28] border-b border-white/10">
       <div class="max-w-6xl px-6 py-24 mx-auto md:px-8 lg:px-12 lg:py-32">
         <div class="flex flex-col items-center text-center gap-10 lg:flex-row lg:items-center lg:justify-between lg:text-left lg:gap-16">
+          <!-- Modified hero logo sizing start -->
           <div class="flex justify-center w-full lg:w-auto lg:justify-start">
             <img
               src="./img/logo.png"
               alt="Halesia Group logo"
-              class="w-32 h-auto lg:w-36"
+              class="w-40 h-auto lg:w-48"
             />
           </div>
+          <!-- Modified hero logo sizing end -->
           <div class="max-w-2xl space-y-6">
             <h1 class="text-3xl font-semibold sm:text-4xl lg:text-5xl">
               Your Technical Partner for Growing Businesses.
@@ -51,7 +54,7 @@
             <div>
               <a
                 href="#contact"
-                class="inline-flex items-center justify-center px-6 py-3 text-base font-medium text-white transition rounded-xl bg-[#0f5f9f] hover:bg-[#0f5f9f]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#0f5f9f] focus-visible:ring-offset-[#0b1a27]"
+                class="inline-flex items-center justify-center px-6 py-3 text-base font-medium text-white transition rounded-xl bg-[#0f5f9f] hover:bg-[#0f5f9f]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#0f5f9f] focus-visible:ring-offset-[#0e1d28]"
               >
                 Book a 20-Minute Call
               </a>
@@ -62,10 +65,10 @@
     </section>
     <!-- Hero section end -->
     <!-- What We Do section start -->
-    <section class="w-full bg-white border-b border-[#0b1a27]/10">
+    <section class="w-full bg-white border-b border-[#0e1d28]/10">
       <div class="max-w-6xl px-6 py-24 mx-auto md:px-8 lg:px-12">
         <div class="text-center">
-          <h2 class="mb-6 text-3xl font-semibold tracking-tight text-[#0b1a27] sm:text-4xl">
+          <h2 class="mb-6 text-3xl font-semibold tracking-tight text-[#0e1d28] sm:text-4xl">
             What We Do
           </h2>
           <p class="max-w-2xl mx-auto mb-4 text-base leading-relaxed text-gray-700">
@@ -73,38 +76,38 @@
           </p>
         </div>
         <div class="grid grid-cols-1 gap-8 mt-16 sm:grid-cols-2 lg:grid-cols-4">
-          <article class="h-full p-8 transition-all border rounded-2xl border-[#0b1a27]/10 bg-white shadow-sm hover:-translate-y-1 hover:shadow-md">
-            <div class="flex items-center justify-center w-12 h-12 rounded-full bg-[#0b1a27]/5">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-7 h-7 text-[#0b1a27]" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 5h14v6H5z" /><path d="M8 11v8" /><path d="M16 11v8" /><path d="M10 15h4" /></svg>
+          <article class="h-full p-8 transition-all border rounded-2xl border-[#0e1d28]/10 bg-white shadow-sm hover:-translate-y-1 hover:shadow-md">
+            <div class="flex items-center justify-center w-12 h-12 rounded-full bg-[#0e1d28]/5">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-7 h-7 text-[#0e1d28]" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 5h14v6H5z" /><path d="M8 11v8" /><path d="M16 11v8" /><path d="M10 15h4" /></svg>
             </div>
-            <h3 class="mt-6 mb-4 text-xl font-semibold text-[#0b1a27]">Custom Platforms</h3>
+            <h3 class="mt-6 mb-4 text-xl font-semibold text-[#0e1d28]">Custom Platforms</h3>
             <p class="mb-4 text-sm leading-relaxed text-gray-700">
               Bespoke web and mobile applications designed around your workflows, built to evolve with your business.
             </p>
           </article>
-          <article class="h-full p-8 transition-all border rounded-2xl border-[#0b1a27]/10 bg-white shadow-sm hover:-translate-y-1 hover:shadow-md">
-            <div class="flex items-center justify-center w-12 h-12 rounded-full bg-[#0b1a27]/5">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-7 h-7 text-[#0b1a27]" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h16" /><path d="M4 12h10" /><path d="M4 17h6" /><path d="M18 10v8" /><path d="m15 15 3 3 3-3" /></svg>
+          <article class="h-full p-8 transition-all border rounded-2xl border-[#0e1d28]/10 bg-white shadow-sm hover:-translate-y-1 hover:shadow-md">
+            <div class="flex items-center justify-center w-12 h-12 rounded-full bg-[#0e1d28]/5">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-7 h-7 text-[#0e1d28]" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h16" /><path d="M4 12h10" /><path d="M4 17h6" /><path d="M18 10v8" /><path d="m15 15 3 3 3-3" /></svg>
             </div>
-            <h3 class="mt-6 mb-4 text-xl font-semibold text-[#0b1a27]">Automation &amp; Integration</h3>
+            <h3 class="mt-6 mb-4 text-xl font-semibold text-[#0e1d28]">Automation &amp; Integration</h3>
             <p class="mb-4 text-sm leading-relaxed text-gray-700">
               Connect the tools you rely on and streamline manual processes with reliable automations tailored to your stack.
             </p>
           </article>
-          <article class="h-full p-8 transition-all border rounded-2xl border-[#0b1a27]/10 bg-white shadow-sm hover:-translate-y-1 hover:shadow-md">
-            <div class="flex items-center justify-center w-12 h-12 rounded-full bg-[#0b1a27]/5">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-7 h-7 text-[#0b1a27]" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 8h12" /><path d="M6 12h12" /><path d="M6 16h8" /><path d="M10 4v2" /><path d="M14 4v2" /><path d="M9 20h6" /></svg>
+          <article class="h-full p-8 transition-all border rounded-2xl border-[#0e1d28]/10 bg-white shadow-sm hover:-translate-y-1 hover:shadow-md">
+            <div class="flex items-center justify-center w-12 h-12 rounded-full bg-[#0e1d28]/5">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-7 h-7 text-[#0e1d28]" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 8h12" /><path d="M6 12h12" /><path d="M6 16h8" /><path d="M10 4v2" /><path d="M14 4v2" /><path d="M9 20h6" /></svg>
             </div>
-            <h3 class="mt-6 mb-4 text-xl font-semibold text-[#0b1a27]">Maintenance &amp; Support</h3>
+            <h3 class="mt-6 mb-4 text-xl font-semibold text-[#0e1d28]">Maintenance &amp; Support</h3>
             <p class="mb-4 text-sm leading-relaxed text-gray-700">
               Proactive monitoring, updates, and on-call experts keep your systems stable so your team can stay focused.
             </p>
           </article>
-          <article class="h-full p-8 transition-all border rounded-2xl border-[#0b1a27]/10 bg-white shadow-sm hover:-translate-y-1 hover:shadow-md">
-            <div class="flex items-center justify-center w-12 h-12 rounded-full bg-[#0b1a27]/5">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-7 h-7 text-[#0b1a27]" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v4" /><path d="M7 11h10" /><path d="M5 21h14" /><path d="M9 7h6l2 4-5 10-5-10z" /></svg>
+          <article class="h-full p-8 transition-all border rounded-2xl border-[#0e1d28]/10 bg-white shadow-sm hover:-translate-y-1 hover:shadow-md">
+            <div class="flex items-center justify-center w-12 h-12 rounded-full bg-[#0e1d28]/5">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-7 h-7 text-[#0e1d28]" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v4" /><path d="M7 11h10" /><path d="M5 21h14" /><path d="M9 7h6l2 4-5 10-5-10z" /></svg>
             </div>
-            <h3 class="mt-6 mb-4 text-xl font-semibold text-[#0b1a27]">Technical Advisory</h3>
+            <h3 class="mt-6 mb-4 text-xl font-semibold text-[#0e1d28]">Technical Advisory</h3>
             <p class="mb-4 text-sm leading-relaxed text-gray-700">
               Strategic guidance on architecture, tooling, and delivery practices to help you make confident technical decisions.
             </p>
@@ -114,10 +117,10 @@
     </section>
     <!-- What We Do section end -->
     <!-- Who We Help section start -->
-    <section class="w-full bg-white border-b border-[#0b1a27]/10">
+    <section class="w-full bg-white border-b border-[#0e1d28]/10">
       <div class="max-w-6xl px-6 py-24 mx-auto md:px-8 lg:px-12">
         <div class="max-w-3xl mx-auto text-center">
-          <h2 class="mb-6 text-3xl font-semibold tracking-tight text-[#0b1a27] sm:text-4xl">
+          <h2 class="mb-6 text-3xl font-semibold tracking-tight text-[#0e1d28] sm:text-4xl">
             Who We Help
           </h2>
           <p class="mb-4 text-base leading-relaxed text-gray-700">
@@ -125,19 +128,19 @@
           </p>
         </div>
         <div class="grid grid-cols-1 gap-4 mt-12 sm:grid-cols-2 lg:grid-cols-3 lg:gap-6">
-          <div class="px-6 py-4 text-sm font-medium text-center transition border rounded-full text-[#0b1a27] border-[#0b1a27]/10 bg-white hover:border-[#0b1a27]/40">
+          <div class="px-6 py-4 text-sm font-medium text-center transition border rounded-full text-[#0e1d28] border-[#0e1d28]/10 bg-white hover:border-[#0e1d28]/40">
             Education &amp; Training
           </div>
-          <div class="px-6 py-4 text-sm font-medium text-center transition border rounded-full text-[#0b1a27] border-[#0b1a27]/10 bg-white hover:border-[#0b1a27]/40">
+          <div class="px-6 py-4 text-sm font-medium text-center transition border rounded-full text-[#0e1d28] border-[#0e1d28]/10 bg-white hover:border-[#0e1d28]/40">
             Manufacturing &amp; Engineering
           </div>
-          <div class="px-6 py-4 text-sm font-medium text-center transition border rounded-full text-[#0b1a27] border-[#0b1a27]/10 bg-white hover:border-[#0b1a27]/40">
+          <div class="px-6 py-4 text-sm font-medium text-center transition border rounded-full text-[#0e1d28] border-[#0e1d28]/10 bg-white hover:border-[#0e1d28]/40">
             Design &amp; Creative Studios
           </div>
-          <div class="px-6 py-4 text-sm font-medium text-center transition border rounded-full text-[#0b1a27] border-[#0b1a27]/10 bg-white hover:border-[#0b1a27]/40">
+          <div class="px-6 py-4 text-sm font-medium text-center transition border rounded-full text-[#0e1d28] border-[#0e1d28]/10 bg-white hover:border-[#0e1d28]/40">
             Professional Services
           </div>
-          <div class="px-6 py-4 text-sm font-medium text-center transition border rounded-full text-[#0b1a27] border-[#0b1a27]/10 bg-white hover:border-[#0b1a27]/40">
+          <div class="px-6 py-4 text-sm font-medium text-center transition border rounded-full text-[#0e1d28] border-[#0e1d28]/10 bg-white hover:border-[#0e1d28]/40">
             Tech Startups
           </div>
         </div>
@@ -145,10 +148,10 @@
     </section>
     <!-- Who We Help section end -->
     <!-- How It Works section start -->
-    <section class="w-full bg-white border-b border-[#0b1a27]/10">
+    <section class="w-full bg-white border-b border-[#0e1d28]/10">
       <div class="max-w-6xl px-6 py-24 mx-auto md:px-8 lg:px-12">
         <div class="max-w-3xl mx-auto text-center">
-          <h2 class="mb-6 text-3xl font-semibold tracking-tight text-[#0b1a27] sm:text-4xl">
+          <h2 class="mb-6 text-3xl font-semibold tracking-tight text-[#0e1d28] sm:text-4xl">
             How It Works
           </h2>
           <p class="mb-4 text-base leading-relaxed text-gray-700">
@@ -159,33 +162,33 @@
           class="grid grid-cols-1 gap-10 mt-16 text-left sm:gap-12 md:grid-cols-3"
         >
           <li class="flex flex-col items-start h-full gap-6">
-            <div class="flex items-center justify-center w-12 h-12 text-lg font-semibold rounded-full text-[#0b1a27] bg-[#0b1a27]/10">
+            <div class="flex items-center justify-center w-12 h-12 text-lg font-semibold rounded-full text-[#0e1d28] bg-[#0e1d28]/10">
               1
             </div>
             <div class="space-y-3">
-              <h3 class="mb-4 text-xl font-semibold text-[#0b1a27]">Discover</h3>
+              <h3 class="mb-4 text-xl font-semibold text-[#0e1d28]">Discover</h3>
               <p class="mb-4 text-sm leading-relaxed text-gray-700">
                 Understand business goals and challenges through collaborative workshops and technical assessments.
               </p>
             </div>
           </li>
           <li class="flex flex-col items-start h-full gap-6">
-            <div class="flex items-center justify-center w-12 h-12 text-lg font-semibold rounded-full text-[#0b1a27] bg-[#0b1a27]/10">
+            <div class="flex items-center justify-center w-12 h-12 text-lg font-semibold rounded-full text-[#0e1d28] bg-[#0e1d28]/10">
               2
             </div>
             <div class="space-y-3">
-              <h3 class="mb-4 text-xl font-semibold text-[#0b1a27]">Build</h3>
+              <h3 class="mb-4 text-xl font-semibold text-[#0e1d28]">Build</h3>
               <p class="mb-4 text-sm leading-relaxed text-gray-700">
                 Design, develop, and deploy the right technical solution with modern tooling and transparent delivery.
               </p>
             </div>
           </li>
           <li class="flex flex-col items-start h-full gap-6">
-            <div class="flex items-center justify-center w-12 h-12 text-lg font-semibold rounded-full text-[#0b1a27] bg-[#0b1a27]/10">
+            <div class="flex items-center justify-center w-12 h-12 text-lg font-semibold rounded-full text-[#0e1d28] bg-[#0e1d28]/10">
               3
             </div>
             <div class="space-y-3">
-              <h3 class="mb-4 text-xl font-semibold text-[#0b1a27]">Maintain</h3>
+              <h3 class="mb-4 text-xl font-semibold text-[#0e1d28]">Maintain</h3>
               <p class="mb-4 text-sm leading-relaxed text-gray-700">
                 Provide continuous monitoring, updates, and improvement so your systems stay resilient and scalable.
               </p>
@@ -196,10 +199,10 @@
     </section>
     <!-- How It Works section end -->
     <!-- About section start -->
-    <section class="w-full bg-white border-b border-[#0b1a27]/10">
+    <section class="w-full bg-white border-b border-[#0e1d28]/10">
       <div class="max-w-6xl px-6 py-24 mx-auto md:px-8 lg:px-12">
         <div class="max-w-3xl mx-auto text-center">
-          <h2 class="mb-6 text-3xl font-semibold tracking-tight text-[#0b1a27] sm:text-4xl">
+          <h2 class="mb-6 text-3xl font-semibold tracking-tight text-[#0e1d28] sm:text-4xl">
             About Halesia Group
           </h2>
           <p class="mb-4 text-base leading-relaxed text-gray-700">
@@ -207,28 +210,28 @@
           </p>
         </div>
         <div class="grid gap-8 mt-12 md:grid-cols-3">
-          <div class="flex flex-col gap-4 p-8 transition-all border rounded-2xl border-[#0b1a27]/10 bg-white shadow-sm hover:shadow-md md:flex-row md:items-start">
-            <div class="hidden w-12 h-12 rounded-full bg-[#0b1a27]/10 md:flex" aria-hidden="true"></div>
+          <div class="flex flex-col gap-4 p-8 transition-all border rounded-2xl border-[#0e1d28]/10 bg-white shadow-sm hover:shadow-md md:flex-row md:items-start">
+            <div class="hidden w-12 h-12 rounded-full bg-[#0e1d28]/10 md:flex" aria-hidden="true"></div>
             <div>
-              <h3 class="mb-4 text-lg font-semibold text-[#0b1a27]">Proven experience</h3>
+              <h3 class="mb-4 text-lg font-semibold text-[#0e1d28]">Proven experience</h3>
               <p class="mb-4 text-sm leading-relaxed text-gray-700">
                 Built and maintained production-grade systems across industries with a focus on reliability.
               </p>
             </div>
           </div>
-          <div class="flex flex-col gap-4 p-8 transition-all border rounded-2xl border-[#0b1a27]/10 bg-white shadow-sm hover:shadow-md md:flex-row md:items-start">
-            <div class="hidden w-12 h-12 rounded-full bg-[#0b1a27]/10 md:flex" aria-hidden="true"></div>
+          <div class="flex flex-col gap-4 p-8 transition-all border rounded-2xl border-[#0e1d28]/10 bg-white shadow-sm hover:shadow-md md:flex-row md:items-start">
+            <div class="hidden w-12 h-12 rounded-full bg-[#0e1d28]/10 md:flex" aria-hidden="true"></div>
             <div>
-              <h3 class="mb-4 text-lg font-semibold text-[#0b1a27]">Ongoing partnership</h3>
+              <h3 class="mb-4 text-lg font-semibold text-[#0e1d28]">Ongoing partnership</h3>
               <p class="mb-4 text-sm leading-relaxed text-gray-700">
                 Continuous improvement, monitoring, and support to keep your software evolving with your business.
               </p>
             </div>
           </div>
-          <div class="flex flex-col gap-4 p-8 transition-all border rounded-2xl border-[#0b1a27]/10 bg-white shadow-sm hover:shadow-md md:flex-row md:items-start">
-            <div class="hidden w-12 h-12 rounded-full bg-[#0b1a27]/10 md:flex" aria-hidden="true"></div>
+          <div class="flex flex-col gap-4 p-8 transition-all border rounded-2xl border-[#0e1d28]/10 bg-white shadow-sm hover:shadow-md md:flex-row md:items-start">
+            <div class="hidden w-12 h-12 rounded-full bg-[#0e1d28]/10 md:flex" aria-hidden="true"></div>
             <div>
-              <h3 class="mb-4 text-lg font-semibold text-[#0b1a27]">Founder-led</h3>
+              <h3 class="mb-4 text-lg font-semibold text-[#0e1d28]">Founder-led</h3>
               <p class="mb-4 text-sm leading-relaxed text-gray-700">
                 Every engagement is overseen by an experienced engineer who stays close to the details.
               </p>
@@ -239,11 +242,11 @@
     </section>
     <!-- About section end -->
     <!-- CTA section start -->
-    <section class="w-full bg-white border-b border-[#0b1a27]/10">
+    <section class="w-full bg-white border-b border-[#0e1d28]/10">
       <div class="max-w-6xl px-6 py-24 mx-auto md:px-8 lg:px-12">
         <div class="flex flex-col items-center justify-between gap-8 text-center md:flex-row md:text-left">
           <div>
-            <h2 class="mb-6 text-3xl font-semibold tracking-tight text-[#0b1a27] sm:text-4xl">
+            <h2 class="mb-6 text-3xl font-semibold tracking-tight text-[#0e1d28] sm:text-4xl">
               Let’s build something that lasts.
             </h2>
             <p class="mb-4 text-base leading-relaxed text-gray-700">
@@ -263,7 +266,7 @@
     </section>
     <!-- CTA section end -->
     <!-- Contact & Footer section start -->
-    <section id="contact" class="w-full text-white border-t border-white/10 bg-[#0b1a27]">
+    <section id="contact" class="w-full text-white border-t border-white/10 bg-[#0e1d28]">
       <div class="max-w-6xl px-6 py-24 mx-auto text-center md:px-8 lg:px-12">
         <h2 class="mb-6 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
           Get in touch.
@@ -274,31 +277,34 @@
         <div class="flex flex-col items-center gap-6 mt-8 sm:flex-row sm:justify-center">
           <a
             href="mailto:hello@halesiagroup.com"
-            class="text-lg font-semibold text-white underline transition decoration-white/60 underline-offset-4 hover:decoration-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#0f5f9f] focus-visible:ring-offset-[#0b1a27]"
+            class="text-lg font-semibold text-white underline transition decoration-white/60 underline-offset-4 hover:decoration-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#0f5f9f] focus-visible:ring-offset-[#0e1d28]"
           >
             hello@halesiagroup.com
           </a>
           <a
             href="https://www.linkedin.com/company/halesiagroup/"
             aria-label="Visit Halesia Group on LinkedIn"
-            class="inline-flex items-center justify-center w-12 h-12 transition-colors border rounded-full border-white/20 bg-white/5 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#0f5f9f] focus-visible:ring-offset-[#0b1a27]"
+            class="inline-flex items-center justify-center w-12 h-12 transition-colors border rounded-full border-white/20 bg-white/5 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#0f5f9f] focus-visible:ring-offset-[#0e1d28]"
           >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6 text-white" aria-hidden="true"><path d="M20.451 20.451h-3.555v-5.569c0-1.328-.027-3.036-1.849-3.036-1.852 0-2.135 1.447-2.135 2.941v5.664H9.357V9h3.414v1.561h.048c.476-.9 1.637-1.849 3.371-1.849 3.607 0 4.273 2.375 4.273 5.467v6.272zM5.337 7.433a2.062 2.062 0 1 1 0-4.124 2.062 2.062 0 0 1 0 4.124zm1.777 13.018H3.56V9h3.554v11.451zM22.225 0H1.771C.792 0 0 .771 0 1.723v20.554C0 23.229.792 24 1.771 24h20.451C23.2 24 24 23.229 24 22.277V1.723C24 .771 23.2 0 22.225 0z" /></svg>
           </a>
         </div>
       </div>
     </section>
-    <footer class="w-full text-white border-t border-white/10 bg-[#0b1a27]">
+    <footer class="w-full text-white border-t border-white/10 bg-[#0e1d28]">
       <div class="max-w-6xl px-6 py-8 mx-auto md:px-8 lg:px-12">
         <div class="flex flex-col items-center justify-between gap-4 text-sm text-gray-100 md:flex-row">
+          <!-- Modified footer logo sizing start -->
           <div class="flex items-center gap-3">
-            <img src="./img/logo.png" alt="Halesia Group" class="h-8 w-auto" />
+            <img src="./img/logo.png" alt="Halesia Group" class="h-10 w-auto" />
             <span class="sr-only">Halesia Group</span>
           </div>
+          <!-- Modified footer logo sizing end -->
           <p class="text-center md:text-right">© 2025 Halesia Group. All rights reserved.</p>
         </div>
       </div>
     </footer>
     <!-- Contact & Footer section end -->
   </body>
+  <!-- Brand palette update end -->
 </html>


### PR DESCRIPTION
## Summary
- enlarge the hero logo to `w-40` / `lg:w-48` while keeping proportional scaling and layout intact
- scale the footer logo up to `h-10` and note updated comments around the modified blocks
- align all dark surfaces with the logo’s #0E1D28 tone, updating theme colour metadata and Tailwind utility classes site-wide

## Testing
- not run (static HTML update)

------
https://chatgpt.com/codex/tasks/task_e_68e2e6a78a38832d97d4b736989bb263