### PR TITLE
Highlight founder experience in about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,9 +245,9 @@
           <div class="flex flex-col gap-4 p-8 transition-all border rounded-2xl border-[#0e1d28]/10 bg-white shadow-sm hover:shadow-md md:flex-row md:items-start">
             <div class="hidden w-12 h-12 rounded-full bg-[#0e1d28]/10 md:flex" aria-hidden="true"></div>
             <div>
-              <h3 class="mb-4 text-lg font-semibold text-[#0e1d28]">Founder-led</h3>
+              <h3 class="mb-4 text-lg font-semibold text-[#0e1d28]">Founder-built team</h3>
               <p class="mb-4 text-sm leading-relaxed text-gray-700">
-                Every engagement is overseen by an experienced engineer who stays close to the details.
+                You work with seasoned entrepreneurs—every lead on our team has built and scaled their own company, so we approach your roadmap with a founder’s urgency and pragmatism.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- update the About section card headline to "Founder-built team"
- emphasize that every lead has founded and scaled companies to reinforce entrepreneurial credibility

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2f4620d84832daad857e4f157258b