### PR TITLE
Reduce hero section height

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
         <div class="w-full h-full bg-gradient-to-b from-[#0a1825] via-[#0b1a27] to-[#0a1825]"></div>
         <div class="absolute inset-0 opacity-40 bg-[radial-gradient(circle_at_top,_rgba(26,50,74,0.45),_transparent_60%)]"></div>
       </div>
-      <div class="relative max-w-6xl px-6 py-32 mx-auto md:px-8 lg:px-12 md:py-48">
+      <div class="relative max-w-6xl px-6 py-24 mx-auto md:px-8 lg:px-12 md:py-40">
         <div class="flex flex-col items-center gap-12 text-center lg:flex-row lg:items-center lg:justify-between lg:text-left lg:gap-20">
           <div class="flex justify-center w-full opacity-0 lg:w-auto lg:justify-start animate-[fadeInUp_0.8s_ease-out_forwards]">
             <img


### PR DESCRIPTION
## Summary
- reduce the hero container padding to shorten the blue hero block height while keeping its contents intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e37fe37440832dbf952d194a330bfc