### PR TITLE
Balance contact section column heights

### DIFF
--- a/index.html
+++ b/index.html
@@ -435,13 +435,13 @@
     <!-- Contact & Footer section start -->
     <section id="contact" class="w-full text-white border-t border-white/10 bg-[#0e1d28]">
       <div class="max-w-6xl px-6 py-24 mx-auto md:px-8 lg:px-12">
-        <div class="grid gap-12 lg:grid-cols-[1.1fr_0.9fr] lg:items-start">
-          <div class="space-y-6">
-            <h2 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Get in touch.</h2>
-            <p class="text-base leading-relaxed text-gray-100">
+        <div class="grid gap-12 lg:grid-cols-[1.1fr_0.9fr] lg:items-stretch">
+          <div class="space-y-6 lg:self-stretch lg:flex lg:flex-col lg:justify-center">
+            <h2 class="text-4xl font-semibold tracking-tight text-white sm:text-5xl">Get in touch.</h2>
+            <p class="text-lg leading-relaxed text-gray-100">
               Tell us where you’re aiming and we’ll map the fastest path to a dependable solution.
             </p>
-            <ul class="space-y-4 text-sm leading-relaxed text-gray-100/90">
+            <ul class="space-y-4 text-base leading-relaxed text-gray-100/90">
               <li class="flex gap-3">
                 <span class="flex items-center justify-center flex-shrink-0 w-6 h-6 mt-0.5 rounded-full bg-white/10">
                   <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
@@ -483,35 +483,34 @@
               </a>
             </div>
           </div>
-          <form class="p-8 space-y-6 bg-white border rounded-3xl shadow-xl border-white/10 shadow-black/10" name="contact" method="post" netlify>
-            <div>
-              <label for="name" class="block text-sm font-semibold text-[#0e1d28]">Name</label>
-              <input id="name" name="name" type="text" required class="w-full px-4 py-3 mt-2 text-base border rounded-lg border-[#0e1d28]/10 focus:border-[#0f5f9f] focus:ring-[#0f5f9f]" placeholder="Jane Doe" />
+          <form class="flex flex-col h-full gap-4 p-6 bg-white border rounded-3xl shadow-xl border-white/10 shadow-black/10" name="contact" method="post" netlify>
+            <div class="grid gap-3 sm:grid-cols-2">
+              <div>
+                <label for="name" class="block text-sm font-semibold text-[#0e1d28]">Name</label>
+                <input id="name" name="name" type="text" required class="w-full px-4 py-1.5 mt-1.5 text-base border rounded-lg border-[#0e1d28]/10 focus:border-[#0f5f9f] focus:ring-[#0f5f9f]" placeholder="Jane Doe" />
+              </div>
+              <div>
+                <label for="email" class="block text-sm font-semibold text-[#0e1d28]">Work email</label>
+                <input id="email" name="email" type="email" required class="w-full px-4 py-1.5 mt-1.5 text-base border rounded-lg border-[#0e1d28]/10 focus:border-[#0f5f9f] focus:ring-[#0f5f9f]" placeholder="jane@company.com" />
+              </div>
+              <div class="sm:col-span-2">
+                <label for="company" class="block text-sm font-semibold text-[#0e1d28]">Company</label>
+                <input id="company" name="company" type="text" class="w-full px-4 py-1.5 mt-1.5 text-base border rounded-lg border-[#0e1d28]/10 focus:border-[#0f5f9f] focus:ring-[#0f5f9f]" placeholder="Acme Inc." />
+              </div>
+              <div class="sm:col-span-2">
+                <label for="goal" class="block text-sm font-semibold text-[#0e1d28]">What do you want to achieve?</label>
+                <textarea id="goal" name="goal" rows="3" required class="w-full px-4 py-1.5 mt-1.5 text-base border rounded-lg border-[#0e1d28]/10 focus:border-[#0f5f9f] focus:ring-[#0f5f9f]" placeholder="Launch a new platform, automate operations, modernise legacy systems…"></textarea>
+              </div>
             </div>
-            <div>
-              <label for="email" class="block text-sm font-semibold text-[#0e1d28]">Work email</label>
-              <input id="email" name="email" type="email" required class="w-full px-4 py-3 mt-2 text-base border rounded-lg border-[#0e1d28]/10 focus:border-[#0f5f9f] focus:ring-[#0f5f9f]" placeholder="jane@company.com" />
-            </div>
-            <div>
-              <label for="company" class="block text-sm font-semibold text-[#0e1d28]">Company</label>
-              <input id="company" name="company" type="text" class="w-full px-4 py-3 mt-2 text-base border rounded-lg border-[#0e1d28]/10 focus:border-[#0f5f9f] focus:ring-[#0f5f9f]" placeholder="Acme Inc." />
-            </div>
-            <div>
-              <label for="goal" class="block text-sm font-semibold text-[#0e1d28]">What do you want to achieve?</label>
-              <textarea id="goal" name="goal" rows="4" required class="w-full px-4 py-3 mt-2 text-base border rounded-lg border-[#0e1d28]/10 focus:border-[#0f5f9f] focus:ring-[#0f5f9f]" placeholder="Launch a new platform, automate operations, modernise legacy systems…"></textarea>
-            </div>
-            <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div class="flex flex-col gap-2 pt-1 sm:flex-row sm:items-center sm:justify-between">
               <label class="inline-flex items-center gap-2 text-sm text-[#0e1d28]">
                 <input type="checkbox" name="subscribe" class="w-4 h-4 text-[#0f5f9f] border-[#0e1d28]/20 rounded focus:ring-[#0f5f9f]" />
                 Keep me posted on playbooks &amp; events
               </label>
-              <button type="submit" class="inline-flex items-center justify-center w-full px-5 py-3 text-base font-semibold text-white transition rounded-lg bg-[#0f5f9f] hover:bg-[#0c4a7b] sm:w-auto">
+              <button type="submit" class="inline-flex items-center justify-center w-full px-5 py-2 text-base font-semibold text-white transition rounded-lg bg-[#0f5f9f] hover:bg-[#0c4a7b] sm:w-auto">
                 Request a clarity call
               </button>
             </div>
-            <p class="text-xs leading-relaxed text-gray-500">
-              We only use your information to follow up about your inquiry. No spam—ever.
-            </p>
           </form>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- increase the left contact column typography so the narrative block visually balances the form
- tighten Calendly form spacing and remove the privacy note so the card height matches the adjacent content
- vertically center the left contact copy with the Calendly card for better alignment

## Testing
- no automated tests (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e37f40be1c832d817db62897a6543d