### PR TITLE
Add hover scaling to remaining booking buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,7 +423,7 @@
           <div class="flex justify-center md:justify-end">
             <a
               href="#contact"
-              class="inline-flex items-center justify-center px-6 py-3 text-base font-medium text-white transition rounded-xl bg-[#0f5f9f] hover:bg-[#0f5f9f]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#0f5f9f] focus-visible:ring-offset-white"
+              class="inline-flex items-center justify-center px-6 py-3 text-base font-medium text-white transition duration-200 transform rounded-xl bg-[#0f5f9f] hover:scale-105 hover:bg-[#0f5f9f]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#0f5f9f] focus-visible:ring-offset-white"
             >
               Book a 20-Minute Call
             </a>
@@ -507,7 +507,7 @@
                 <input type="checkbox" name="subscribe" class="w-4 h-4 text-[#0f5f9f] border-[#0e1d28]/20 rounded focus:ring-[#0f5f9f]" />
                 Keep me posted on playbooks &amp; events
               </label>
-              <button type="submit" class="inline-flex items-center justify-center w-full px-5 py-2 text-base font-semibold text-white transition rounded-lg bg-[#0f5f9f] hover:bg-[#0c4a7b] sm:w-auto">
+              <button type="submit" class="inline-flex items-center justify-center w-full px-5 py-2 text-base font-semibold text-white transition duration-200 transform rounded-lg bg-[#0f5f9f] hover:scale-105 hover:bg-[#0c4a7b] sm:w-auto">
                 Request a clarity call
               </button>
             </div>


### PR DESCRIPTION
## Summary
- add the same hover scaling behavior from the hero CTA to the mid-page booking link
- apply the hover scale interaction to the contact form submit button

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e38682c1ac832d85e29b87bccc2bc8