### PR TITLE
Adjust diagnostic image panel heights

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,7 +387,7 @@
           </div>
           <div class="flex flex-col h-full gap-6">
             <figure
-              class="flex flex-1 w-full min-h-[320px] overflow-hidden rounded-2xl border border-[#0e1d28]/10 bg-white shadow-sm"
+              class="flex flex-1 w-full min-h-[260px] overflow-hidden rounded-2xl border border-[#0e1d28]/10 bg-white shadow-sm"
             >
               <img
                 src="./img/Picture%201.png"
@@ -396,7 +396,7 @@
               />
             </figure>
             <figure
-              class="flex flex-1 w-full min-h-[320px] overflow-hidden rounded-2xl border border-[#0e1d28]/10 bg-white shadow-sm"
+              class="flex flex-1 w-full min-h-[260px] overflow-hidden rounded-2xl border border-[#0e1d28]/10 bg-white shadow-sm"
             >
               <img
                 src="./img/Picture%202.png"


### PR DESCRIPTION
## Summary
- reduce the minimum height of the Clarity Diagnostic image cards so the stack aligns with the text column

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3940caf48832db405c7c4ff187211