### PR TITLE
Ensure hero section is visible on initial load

### DIFF
--- a/index.html
+++ b/index.html
@@ -720,6 +720,27 @@
       </div>
     </footer>
     <!-- Contact & Footer section end -->
+    <!-- Ensure hero is the initial viewport start -->
+    <script>
+      (function () {
+        if ("scrollRestoration" in history) {
+          history.scrollRestoration = "manual";
+        }
+
+        const resetScroll = () => {
+          if (!window.location.hash) {
+            window.scrollTo(0, 0);
+          }
+        };
+
+        if (document.readyState === "complete") {
+          resetScroll();
+        } else {
+          window.addEventListener("load", resetScroll, { once: true });
+        }
+      })();
+    </script>
+    <!-- Ensure hero is the initial viewport end -->
     <!-- How It Works animation script start -->
     <script>
       (function () {


### PR DESCRIPTION
## Summary
- add a script that disables scroll restoration and scrolls to the top when no hash is present
- ensure the hero remains the first section a visitor sees on fresh loads

## Testing
- python3 -m http.server 3000

------
https://chatgpt.com/codex/tasks/task_e_68e3968c8988832d86ed2caa2b176501