### PR TITLE
Fix clarity diagnostic image alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,7 +331,7 @@
     <!-- Conversion assets section start -->
     <section class="w-full bg-[#f5f8fb] border-b border-[#0e1d28]/10">
       <div class="max-w-6xl px-6 py-24 mx-auto md:px-8 lg:px-12">
-        <div class="grid gap-12 items-start lg:items-stretch lg:grid-cols-[1.1fr_0.9fr]">
+        <div class="grid gap-12 lg:items-stretch lg:grid-cols-[1.1fr_0.9fr]">
           <div class="space-y-6">
             <h2 class="text-3xl font-semibold tracking-tight text-[#0e1d28] sm:text-4xl">
               Start with a Clarity Diagnostic


### PR DESCRIPTION
## Summary
- allow the Clarity Diagnostic grid columns to stretch to an equal height on large layouts
- remove the restrictive align-items setting that prevented the image column from matching the form column height

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e39c206258832da8858c822f47f960