### PR TITLE
Expand FAQ list and adjust spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -600,7 +600,7 @@
           </div>
           <div class="space-y-8">
             <h3 class="text-3xl font-semibold tracking-tight text-[#0e1d28]">Frequently asked questions</h3>
-            <div class="space-y-6">
+            <div class="space-y-7">
               <details class="p-6 space-y-2 bg-white border rounded-2xl border-[#0e1d28]/10">
                 <summary class="text-base font-semibold text-[#0e1d28] cursor-pointer">What does working with a founder-led team look like?</summary>
                 <p class="text-sm leading-relaxed text-gray-700">You’ll work directly with the founders during strategy, architecture, and critical delivery phases. As the engagement scales, we plug in trusted specialists while staying accountable for quality, timelines, and communication.</p>
@@ -616,6 +616,10 @@
               <details class="p-6 space-y-2 bg-white border rounded-2xl border-[#0e1d28]/10">
                 <summary class="text-base font-semibold text-[#0e1d28] cursor-pointer">What happens after launch?</summary>
                 <p class="text-sm leading-relaxed text-gray-700">Every engagement includes an operational handbook, monitoring setup, and optional success metrics dashboard. You choose between ongoing maintenance support or a structured handover.</p>
+              </details>
+              <details class="p-6 space-y-2 bg-white border rounded-2xl border-[#0e1d28]/10">
+                <summary class="text-base font-semibold text-[#0e1d28] cursor-pointer">How fast can a project kick off?</summary>
+                <p class="text-sm leading-relaxed text-gray-700">Most teams start within two weeks. We use the initial clarity call to scope must-haves, then launch a discovery sprint to confirm architecture, staffing, and delivery milestones before execution begins.</p>
               </details>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add a new kickoff timeline FAQ entry to the risk reversal section
- increase the spacing between FAQ cards so the column aligns with the delivery assurance block

## Testing
- npm run test:structure *(fails: jest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a2bee6fc832d8a014867847f823c