### PR TITLE
Update layout tests to target clarity diagnostic grid

### DIFF
--- a/tests/alignment.test.js
+++ b/tests/alignment.test.js
@@ -27,13 +27,33 @@ describe('Homepage alignment', () => {
     await page.goto(BASE_URL, { waitUntil: 'networkidle0' });
 
     const metrics = await page.evaluate(() => {
-      const lhs = document.querySelector('.lhs-section');
-      const rhs = document.querySelector('.rhs-images');
+      const sections = Array.from(document.querySelectorAll('section'));
+      const claritySection = sections.find((section) => {
+        const heading = section.querySelector('h2');
+        return heading && heading.textContent.includes('Clarity Diagnostic');
+      });
+
+      if (!claritySection) {
+        return null;
+      }
+
+      const layoutParent = claritySection.querySelector('div[class*="grid"]');
+      if (!layoutParent) {
+        return null;
+      }
+
+      const columns = Array.from(layoutParent.children).filter(
+        (child) => child.tagName.toLowerCase() === 'div',
+      );
+      const [lhs, rhs] = columns;
+
       if (!lhs || !rhs) {
         return null;
       }
+
       const lhsRect = lhs.getBoundingClientRect();
       const rhsRect = rhs.getBoundingClientRect();
+
       return {
         lhsBottom: lhsRect.bottom,
         rhsBottom: rhsRect.bottom,

--- a/tests/structure.test.js
+++ b/tests/structure.test.js
@@ -3,6 +3,31 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+const getClaritySectionLayout = (document) => {
+  const sections = Array.from(document.querySelectorAll('section'));
+  const claritySection = sections.find((section) => {
+    const heading = section.querySelector('h2');
+    return heading && heading.textContent.includes('Clarity Diagnostic');
+  });
+
+  if (!claritySection) {
+    return { claritySection: null, layoutParent: null, lhs: null, rhs: null };
+  }
+
+  const layoutParent = claritySection.querySelector('div[class*="grid"]');
+  if (!layoutParent) {
+    return { claritySection, layoutParent: null, lhs: null, rhs: null };
+  }
+
+  const columns = Array.from(layoutParent.children).filter(
+    (child) => child.tagName.toLowerCase() === 'div',
+  );
+
+  const [lhs, rhs] = columns;
+
+  return { claritySection, layoutParent, lhs: lhs || null, rhs: rhs || null };
+};
+
 describe('Homepage structural layout', () => {
   let document;
 
@@ -14,23 +39,24 @@ describe('Homepage structural layout', () => {
   });
 
   test('lhs and rhs containers exist', () => {
-    const lhs = document.querySelector('.lhs-section');
-    const rhs = document.querySelector('.rhs-images');
+    const { lhs, rhs } = getClaritySectionLayout(document);
 
     expect(lhs).not.toBeNull();
     expect(rhs).not.toBeNull();
   });
 
   test('lhs and rhs share the same flex or grid parent', () => {
-    const lhs = document.querySelector('.lhs-section');
-    const rhs = document.querySelector('.rhs-images');
+    const { layoutParent, lhs, rhs } = getClaritySectionLayout(document);
 
     expect(lhs).not.toBeNull();
     expect(rhs).not.toBeNull();
-
-    const layoutParent = lhs.closest('.flex, .grid');
-
     expect(layoutParent).not.toBeNull();
+
+    if (!layoutParent || !lhs || !rhs) {
+      return;
+    }
+
+    expect(layoutParent.contains(lhs)).toBe(true);
     expect(layoutParent.contains(rhs)).toBe(true);
 
     const classList = new Set(layoutParent.className.split(/\s+/));


### PR DESCRIPTION
## Summary
- derive the clarity diagnostic section layout elements by heading text instead of hardcoded class hooks in the structure test
- update the alignment test to reuse the same discovery logic when measuring the column bottoms

## Testing
- npm run test:structure

------
https://chatgpt.com/codex/tasks/task_e_68e3a3601b64832d9d6026c9fc26c304