### PR TITLE
Adjust featured engagement layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@
           </div>
           <aside class="p-8 space-y-6 transition border rounded-3xl border-[#0e1d28]/10 bg-white shadow-lg shadow-[#0e1d28]/5">
             <figure class="overflow-hidden rounded-2xl border border-[#0e1d28]/10">
-              <img src="./img/case-study-marketplace.jpg" alt="Product team collaborating around marketplace dashboards" class="object-cover w-full h-48" />
+              <img src="./img/case-study-marketplace.jpg" alt="Product team collaborating around marketplace dashboards" class="object-cover w-full h-[20.4rem]" />
             </figure>
             <h3 class="text-2xl font-semibold text-[#0e1d28]">Featured engagement</h3>
             <p class="text-base leading-relaxed text-gray-700">
@@ -206,15 +206,6 @@
                 Post-launch support roadmap aligned engineering sprints with revenue targets.
               </li>
             </ul>
-            <div class="pt-4 border-t border-[#0e1d28]/10">
-              <p class="text-sm font-medium text-[#0e1d28]">Curious what this could look like for you?</p>
-              <a href="#contact" class="inline-flex items-center mt-3 text-sm font-semibold text-[#0f5f9f] hover:text-[#0c4a7b]">
-                Request a teardown
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 ml-1">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="m5 13 4 4L19 7" />
-                </svg>
-              </a>
-            </div>
           </aside>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove the featured engagement call-to-action copy from the sidebar
- increase the featured engagement image height for a taller presentation

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e3c9c2f098832d9153ce49c83ad572