### PR TITLE
Adjust clarity call button alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,8 +466,8 @@
                 <textarea id="goal" name="goal" rows="3" required class="w-full px-4 py-1.5 mt-1.5 text-base border rounded-lg border-[#0e1d28]/10 focus:border-[#0f5f9f] focus:ring-[#0f5f9f]" placeholder="Launch a new platform, automate operations, modernise legacy systems…"></textarea>
               </div>
             </div>
-            <div class="flex flex-col gap-2 pt-1 sm:flex-row sm:items-center sm:justify-between">
-              <button type="submit" class="inline-flex items-center justify-center w-full px-5 py-2 text-base font-semibold text-white transition duration-200 transform rounded-lg bg-[#0f5f9f] hover:scale-105 hover:bg-[#0c4a7b] sm:w-auto">
+            <div class="flex flex-col w-full gap-2 pt-1 sm:flex-row sm:items-center sm:justify-center">
+              <button type="submit" class="inline-flex items-center justify-center w-full px-5 py-2 text-base font-semibold text-white transition duration-200 transform rounded-lg bg-[#0f5f9f] hover:scale-105 hover:bg-[#0c4a7b]">
                 Request a clarity call
               </button>
             </div>


### PR DESCRIPTION
## Summary
- center the clarity call form controls so the request button spans the form width on all screen sizes

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e3db45bd90832d9cdc876b2b393fe9