### PR TITLE
Point Tailwind build at existing Tailwind source

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install
 
 ## Development
 
-Run TailwindCSS in watch mode to rebuild `style.css` as you edit HTML or CSS.
+Run TailwindCSS in watch mode to rebuild `style.css` as you edit `src/styles/tailwind.css` or HTML templates.
 
 ```bash
 npm run dev
@@ -18,7 +18,7 @@ npm run dev
 
 ## Production build
 
-Generate a minified production build of `style.css`.
+Generate a minified production build of `style.css` from `src/styles/tailwind.css`.
 
 ```bash
 npm run build


### PR DESCRIPTION
## Summary
- retarget the Tailwind CLI scripts to use the committed `src/styles/tailwind.css`
- restore the stylesheet filename and document the correct source file in the README

## Testing
- `npx tailwindcss -i ./src/styles/tailwind.css -o ./style.css --minify`


------
https://chatgpt.com/codex/tasks/task_e_68e3e0f37540832d9228a28172e7f323