### PR TITLE
Connect contact forms to backend APIs

### DIFF
--- a/index.html
+++ b/index.html
@@ -590,11 +590,6 @@
         const forms = document.querySelectorAll('[data-form]');
         if (!forms.length) return;
 
-        const simulateSubmission = () =>
-          new Promise((resolve) => {
-            window.setTimeout(resolve, 1500);
-          });
-
         forms.forEach((form) => {
           const statusElement = form.querySelector('[data-form-status]');
           const submitButton = form.querySelector('[type="submit"]');
@@ -611,8 +606,53 @@
             submitButton.disabled = true;
 
             try {
-              // TODO: Replace simulateSubmission with a real fetch() call to the backend.
-              await simulateSubmission();
+              const formType = form.getAttribute('data-form');
+              const endpointMap = {
+                diagnostic: '/api/clarity-diagnostic',
+                contact: '/api/clarity-call',
+              };
+
+              const endpoint = endpointMap[formType];
+
+              if (!endpoint) {
+                throw new Error('Unsupported form submission.');
+              }
+
+              const formData = new FormData(form);
+              const payload = {};
+
+              formData.forEach((value, key) => {
+                if (Object.prototype.hasOwnProperty.call(payload, key)) {
+                  const currentValue = payload[key];
+
+                  if (Array.isArray(currentValue)) {
+                    currentValue.push(value);
+                  } else {
+                    payload[key] = [currentValue, value];
+                  }
+                } else {
+                  payload[key] = value;
+                }
+              });
+
+              // Submit the form data to the backend API endpoints.
+              const response = await fetch(endpoint, {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(payload),
+              });
+
+              const contentType = response.headers.get('content-type') || '';
+
+              if (contentType.includes('application/json')) {
+                await response.json().catch(() => undefined);
+              }
+
+              if (!response.ok) {
+                throw new Error('Request failed');
+              }
 
               statusElement.textContent = 'Message sent successfully.';
               form.reset();


### PR DESCRIPTION
## Summary
- replace the simulated form submission placeholder with real POST requests
- send each form to its corresponding clarity diagnostic or clarity call API endpoint
- keep the existing user feedback flow while wiring the forms to the backend responses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e578023db0832d86f22405ac14946d