### PR TITLE
Wire up Resend-backed form submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,4 @@ npm run build
 
 ## Cloudflare deployment
 
-The site is configured for Cloudflare Pages with Functions-based API routes in `functions/api`. To enable email delivery for
-the Clarity Diagnostic and Clarity Call forms:
-
-- Set the `ZOHO_USER` and `ZOHO_PASS` secrets in your Cloudflare project settings (for both Pages and Workers environments).
-- Deploy with those secrets available so the serverless functions can authenticate to Zoho's SMTP service.
-
-Each form submits via POST to `/api/clarity-diagnostic` or `/api/clarity-call`, which will validate the payload, reject spam
-via a honeypot field, and send the message to `info@halesiagroup.com` using the configured Zoho credentials.
+Set the `RESEND_API_KEY` secret in your Cloudflare Pages project settings so Functions can authenticate to Resend. The Clarity Diagnostic and Clarity Call forms post to `/api/clarity-diagnostic` and `/api/clarity-call`. Emails are sent from Resend's authenticated domain (`Website Forms <onboarding@resend.dev>`) with `Reply-To: info@halesiagroup.com`.

--- a/functions/api/_form-handler.js
+++ b/functions/api/_form-handler.js
@@ -2,6 +2,20 @@ import { sendEmail } from './_mailer.js';
 
 const RESPONSE_HEADERS = {
   'Content-Type': 'application/json',
+  'Cache-Control': 'no-store',
+};
+
+const RATE_LIMIT_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+const RATE_LIMIT_MAX_REQUESTS = 5;
+const rateLimitStore = new Map();
+
+const DEFAULT_FIELD_LIMIT = 4000;
+const FIELD_LIMITS = {
+  email: 320,
+  name: 200,
+  company: 200,
+  priority: 2000,
+  goal: 4000,
 };
 
 const escapeHtml = (value) =>
@@ -29,13 +43,77 @@ const parseBody = async (request) => {
   return {};
 };
 
+const getClientIp = (request) => {
+  const cfIp = request.headers.get('cf-connecting-ip');
+  if (cfIp) return cfIp;
+
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) {
+    return forwarded.split(',')[0].trim();
+  }
+
+  return 'unknown';
+};
+
+const isRateLimited = (ip) => {
+  if (!ip || ip === 'unknown') {
+    return false;
+  }
+
+  const now = Date.now();
+  const entry = rateLimitStore.get(ip);
+
+  if (!entry || entry.expires <= now) {
+    rateLimitStore.set(ip, {
+      count: 1,
+      expires: now + RATE_LIMIT_WINDOW_MS,
+    });
+    return false;
+  }
+
+  if (entry.count >= RATE_LIMIT_MAX_REQUESTS) {
+    entry.count += 1;
+    rateLimitStore.set(ip, entry);
+    return true;
+  }
+
+  entry.count += 1;
+  rateLimitStore.set(ip, entry);
+  return false;
+};
+
+const enforceFieldLimits = (data) => {
+  for (const [key, value] of Object.entries(data)) {
+    if (value === undefined || value === null) continue;
+    const limit = FIELD_LIMITS[key] ?? DEFAULT_FIELD_LIMIT;
+    if (sanitize(value).length > limit) {
+      return `Field "${key}" exceeds the maximum allowed length.`;
+    }
+  }
+  return null;
+};
+
+const createErrorResponse = (status, message) =>
+  new Response(
+    JSON.stringify({
+      ok: false,
+      error: message,
+    }),
+    {
+      status,
+      headers: RESPONSE_HEADERS,
+    }
+  );
+
 export function createFormHandler({ requiredFields, subject, prepareContent }) {
   return async function onRequest({ request, env }) {
     if (request.method !== 'POST') {
-      return new Response(JSON.stringify({ error: 'Method Not Allowed' }), {
-        status: 405,
-        headers: RESPONSE_HEADERS,
-      });
+      return createErrorResponse(405, 'Method Not Allowed');
+    }
+
+    const clientIp = getClientIp(request);
+    if (isRateLimited(clientIp)) {
+      return createErrorResponse(429, 'Too many submissions. Please try again later.');
     }
 
     let data;
@@ -43,31 +121,25 @@ export function createFormHandler({ requiredFields, subject, prepareContent }) {
     try {
       data = await parseBody(request);
     } catch (error) {
-      return new Response(JSON.stringify({ error: 'Invalid request payload.' }), {
-        status: 400,
-        headers: RESPONSE_HEADERS,
-      });
+      return createErrorResponse(400, 'Invalid request payload.');
     }
 
     const honeypot = sanitize(data.website || data.honeypot || data.bot_field);
     if (honeypot) {
-      return new Response(JSON.stringify({ error: 'Request rejected.' }), {
-        status: 400,
-        headers: RESPONSE_HEADERS,
-      });
+      return createErrorResponse(400, 'Request rejected.');
+    }
+
+    const lengthError = enforceFieldLimits(data);
+    if (lengthError) {
+      return createErrorResponse(400, lengthError);
     }
 
     const missingFields = requiredFields.filter((field) => !sanitize(data[field]));
 
     if (missingFields.length) {
-      return new Response(
-        JSON.stringify({
-          error: `Missing required field${missingFields.length > 1 ? 's' : ''}: ${missingFields.join(', ')}`,
-        }),
-        {
-          status: 400,
-          headers: RESPONSE_HEADERS,
-        }
+      return createErrorResponse(
+        400,
+        `Missing required field${missingFields.length > 1 ? 's' : ''}: ${missingFields.join(', ')}`
       );
     }
 
@@ -76,43 +148,34 @@ export function createFormHandler({ requiredFields, subject, prepareContent }) {
     try {
       content = prepareContent({ sanitize, escapeHtml }, data);
     } catch (error) {
-      return new Response(JSON.stringify({ error: 'Unable to process submission.' }), {
-        status: 500,
-        headers: RESPONSE_HEADERS,
-      });
+      return createErrorResponse(500, 'Unable to process submission.');
     }
+
+    const computedSubject =
+      typeof subject === 'function' ? subject({ sanitize }, data) : String(subject || 'Website form submission');
 
     try {
       await sendEmail(env, {
-        subject,
+        subject: computedSubject,
         text: content.text,
         html: content.html,
-        replyTo: sanitize(data.email),
       });
 
-      return new Response(
-        JSON.stringify({ message: 'Submission received. We will reply shortly.' }),
-        {
-          status: 200,
-          headers: RESPONSE_HEADERS,
-        }
-      );
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: RESPONSE_HEADERS,
+      });
     } catch (error) {
       console.error('Email sending failed', error);
 
-      const status = error.message && error.message.includes('credentials') ? 500 : 502;
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : 'We could not send your message at this time. Please try again later.';
 
-      const response = {
-        error:
-          status === 500
-            ? 'Email service not configured. Please configure ZOHO_USER and ZOHO_PASS environment variables.'
-            : 'We could not send your message at this time. Please try again later.',
-      };
+      const status = message.includes('credentials') ? 500 : 502;
 
-      return new Response(JSON.stringify(response), {
-        status,
-        headers: RESPONSE_HEADERS,
-      });
+      return createErrorResponse(status, message);
     }
   };
 }

--- a/functions/api/clarity-call.js
+++ b/functions/api/clarity-call.js
@@ -2,7 +2,10 @@ import { createFormHandler } from './_form-handler.js';
 
 const handler = createFormHandler({
   requiredFields: ['name', 'email', 'goal'],
-  subject: 'New Clarity Call Request',
+  subject({ sanitize }, data) {
+    const email = sanitize(data.email) || 'unknown email';
+    return `Clarity Call Request from ${email}`;
+  },
   prepareContent({ sanitize, escapeHtml }, data) {
     const name = sanitize(data.name);
     const email = sanitize(data.email);

--- a/functions/api/clarity-diagnostic.js
+++ b/functions/api/clarity-diagnostic.js
@@ -2,7 +2,10 @@ import { createFormHandler } from './_form-handler.js';
 
 const handler = createFormHandler({
   requiredFields: ['email', 'priority'],
-  subject: 'New Clarity Diagnostic Request',
+  subject({ sanitize }, data) {
+    const email = sanitize(data.email) || 'unknown email';
+    return `Clarity Diagnostic Request from ${email}`;
+  },
   prepareContent({ sanitize, escapeHtml }, data) {
     const email = sanitize(data.email);
     const priority = sanitize(data.priority);

--- a/index.html
+++ b/index.html
@@ -280,7 +280,7 @@
               </li>
             </ul>
             <div class="p-6 space-y-4 transition border rounded-2xl border-[#0e1d28]/15 bg-white shadow-sm">
-              <form class="space-y-4" data-form="diagnostic" method="post" name="clarity-diagnostic">
+              <form class="space-y-4" data-form="diagnostic" method="post" action="/api/clarity-diagnostic" name="clarity-diagnostic">
                 <div class="hidden" aria-hidden="true">
                   <label for="diagnostic-website" class="sr-only">Website</label>
                   <input
@@ -472,7 +472,7 @@
               </a>
             </div>
           </div>
-          <form class="flex flex-col h-full gap-4 p-6 bg-white border rounded-3xl shadow-xl border-white/10 shadow-black/10" name="contact" method="post" data-form="contact">
+          <form class="flex flex-col h-full gap-4 p-6 bg-white border rounded-3xl shadow-xl border-white/10 shadow-black/10" name="contact" method="post" action="/api/clarity-call" data-form="contact">
             <div class="hidden" aria-hidden="true">
               <label for="contact-website" class="sr-only">Website</label>
               <input
@@ -606,14 +606,7 @@
             submitButton.disabled = true;
 
             try {
-              const formType = form.getAttribute('data-form');
-              const endpointMap = {
-                diagnostic: '/api/clarity-diagnostic',
-                contact: '/api/clarity-call',
-              };
-
-              const endpoint = endpointMap[formType];
-
+              const endpoint = form.getAttribute('action');
               if (!endpoint) {
                 throw new Error('Unsupported form submission.');
               }
@@ -645,18 +638,20 @@
               });
 
               const contentType = response.headers.get('content-type') || '';
+              let result;
 
               if (contentType.includes('application/json')) {
-                await response.json().catch(() => undefined);
+                result = await response.json().catch(() => undefined);
               }
 
-              if (!response.ok) {
-                throw new Error('Request failed');
+              if (!response.ok || (result && result.ok === false)) {
+                throw new Error((result && result.error) || 'Request failed');
               }
 
               statusElement.textContent = 'Message sent successfully.';
               form.reset();
             } catch (error) {
+              console.error(error);
               statusElement.textContent = 'There was an error. Please try again.';
             } finally {
               submitButton.disabled = false;

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
     "dev": "npx tailwindcss -i ./src/styles/style.css -o ./style.css --watch --postcss",
     "build": "npx tailwindcss -i ./src/styles/style.css -o ./style.css --minify --postcss"
   },
-  "dependencies": {
-    "nodemailer": "^6.9.11"
-  },
   "devDependencies": {
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.35",


### PR DESCRIPTION
## Summary
- replace the Zoho/nodemailer transport with a Resend HTTP mailer that uses the provider domain for From and Reply-To info@halesiagroup.com
- harden the shared form handler with rate limiting, field length caps, consistent JSON responses, and subjects that include the submitter email
- point both public forms at their API endpoints for native POST fallback, keep the JS enhancement targeting the same route, and document the Resend secret requirement

## Testing
- npm run build
- rg "from ['\"](?:nodemailer|fs|net|tls|crypto|stream|child_process|events|zlib|path|url|util)['\"]"
- rg "require\(['\"](?:nodemailer|fs|net|tls|crypto|stream|child_process|events|zlib|path|url|util)['\"]\)"
- Clarity Diagnostic form: verified name attributes, POST action, fetch enhancement updates the existing status element
- Clarity Call form: verified name attributes, POST action, fetch enhancement updates the existing status element
- Handlers accept JSON & URL-encoded bodies, return { ok: true } on success, and { ok: false, error } otherwise
- Email payload sends from Resend’s authenticated domain with Reply-To info@halesiagroup.com

------
https://chatgpt.com/codex/tasks/task_e_68e57be0ba18832da8028067417ff0de