### PR TITLE
Fix contact form text color visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -472,7 +472,7 @@
               </a>
             </div>
           </div>
-          <form class="flex flex-col h-full gap-4 p-6 bg-white border rounded-3xl shadow-xl border-white/10 shadow-black/10" name="contact" method="post" action="/api/clarity-call" data-form="contact">
+          <form class="flex flex-col h-full gap-4 p-6 bg-white border rounded-3xl shadow-xl border-white/10 shadow-black/10 text-[#0e1d28]" name="contact" method="post" action="/api/clarity-call" data-form="contact">
             <div class="hidden" aria-hidden="true">
               <label for="contact-website" class="sr-only">Website</label>
               <input


### PR DESCRIPTION
## Summary
- ensure the contact form uses the brand text color so entered input is readable against the white background

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e588b8f454832d93c324b0a40b7534