### PR TITLE
Set reply-to headers for form submission emails

### DIFF
--- a/functions/api/_form-handler.js
+++ b/functions/api/_form-handler.js
@@ -154,11 +154,15 @@ export function createFormHandler({ requiredFields, subject, prepareContent }) {
     const computedSubject =
       typeof subject === 'function' ? subject({ sanitize }, data) : String(subject || 'Website form submission');
 
+    const replyToEmail = sanitize(data.email);
+
     try {
       await sendEmail(env, {
         subject: computedSubject,
         text: content.text,
         html: content.html,
+        // Populate the Reply-To header with the visitor's email so responses go directly to them.
+        replyTo: replyToEmail,
       });
 
       return new Response(JSON.stringify({ ok: true }), {

--- a/functions/api/_mailer.js
+++ b/functions/api/_mailer.js
@@ -1,7 +1,7 @@
 const RESEND_API_URL = 'https://api.resend.com/emails';
 const FROM_ADDRESS = 'Website Forms <onboarding@resend.dev>';
 const TO_ADDRESS = 'info@halesiagroup.com';
-const REPLY_TO = 'info@halesiagroup.com';
+const DEFAULT_REPLY_TO = 'info@halesiagroup.com';
 
 async function parseError(response) {
   const contentType = response.headers.get('content-type') || '';
@@ -26,7 +26,7 @@ async function parseError(response) {
   return `Email provider responded with status ${response.status}`;
 }
 
-export async function sendEmail(env, { subject, text, html }) {
+export async function sendEmail(env, { subject, text, html, replyTo }) {
   const apiKey = env?.RESEND_API_KEY;
 
   if (!apiKey) {
@@ -45,7 +45,7 @@ export async function sendEmail(env, { subject, text, html }) {
       subject,
       text,
       html,
-      reply_to: REPLY_TO,
+      reply_to: replyTo || DEFAULT_REPLY_TO,
     }),
   });
 

--- a/functions/api/clarity-call.js
+++ b/functions/api/clarity-call.js
@@ -1,6 +1,7 @@
 import { createFormHandler } from './_form-handler.js';
 
 const handler = createFormHandler({
+  // Reply-To is now set dynamically from the visitor's email in the shared form handler.
   requiredFields: ['name', 'email', 'goal'],
   subject({ sanitize }, data) {
     const email = sanitize(data.email) || 'unknown email';

--- a/functions/api/clarity-diagnostic.js
+++ b/functions/api/clarity-diagnostic.js
@@ -1,6 +1,7 @@
 import { createFormHandler } from './_form-handler.js';
 
 const handler = createFormHandler({
+  // Reply-To is now set dynamically from the visitor's email in the shared form handler.
   requiredFields: ['email', 'priority'],
   subject({ sanitize }, data) {
     const email = sanitize(data.email) || 'unknown email';


### PR DESCRIPTION
## Summary
- update the shared form handler to send the visitor's email as the Reply-To header in Resend submissions
- keep the existing Resend from/to addresses while providing a fallback Reply-To value
- document the dynamic Reply-To behavior in the Clarity Call and Clarity Diagnostic form handlers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e58a6445c4832dbacf57af7bbfcf40