### PR TITLE
Document dynamic reply-to behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ npm run build
 
 ## Cloudflare deployment
 
-Set the `RESEND_API_KEY` secret in your Cloudflare Pages project settings so Functions can authenticate to Resend. The Clarity Diagnostic and Clarity Call forms post to `/api/clarity-diagnostic` and `/api/clarity-call`. Emails are sent from Resend's authenticated domain (`Website Forms <onboarding@resend.dev>`) with `Reply-To: info@halesiagroup.com`.
+Set the `RESEND_API_KEY` secret in your Cloudflare Pages project settings so Functions can authenticate to Resend. The Clarity Diagnostic and Clarity Call forms post to `/api/clarity-diagnostic` and `/api/clarity-call`. Emails are sent from Resend's authenticated domain (`Website Forms <onboarding@resend.dev>`) and dynamically set the `Reply-To` header to the visitor's submitted email (falling back to `info@halesiagroup.com` if unavailable).


### PR DESCRIPTION
## Summary
- update the Cloudflare deployment documentation to reflect that the Reply-To header is now populated from the visitor's email address

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e58e72426c832d9ba5b704e7e35b4a